### PR TITLE
Introduce ULOSINO Tempo and button links for OS pages

### DIFF
--- a/STACK.md
+++ b/STACK.md
@@ -52,30 +52,30 @@ These are the primary providers:
 
 `title`, `summary`, `date`, `platform` and `version` are required for sorting. All other metadata fields will be hidden if they have no value. Updated with version 1.4.0.
 
-| Metadata            | Meaning                                                                                                                 |
-| ------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `title`             | Name of the OS                                                                                                          |
-| `summary`           | Short description of the OS (2-7 words)                                                                                 |
-| `date`              | Date of writing. Year-Month-Date format                                                                                 |
-| `version`           | Version of the OS when written (or written on)                                                                          |
-| `category`          | Category of the OS. See below for more information                                                                      |
-| `platform`          | Popular available platforms, separated by commas                                                                        |
-| `descends`          | The OS that the OS of writing is based on (e.g. Xubuntu/Ubuntu)                                                         |
-| `desktop`           | Name of the preinstalled GUI. To be left blank if none is present, or if the OS boots its CLI by default                |
-| `shell`             | Name of the default shell (e.g. `bash`)                                                                                 |
-| `packagemgr`        | Name of the default package manager. Excludes cross-OS application delivery platforms (e.g. `flatpak`, `snap`)          |
-| `startup`           | Name of the default startup manager (e.g. `systemd`)                                                                    |
-| `size`              | Approximated size of the OS                                                                                             |
-| `browser`           | Name of the preinstalled web browser (e.g. Firefox)                                                                     |
-| `productivity`      | Name of the preinstalled office software suite (e.g. LibreOffice)                                                       |
-| `licence`           | Name of the licence used by the OS (e.g. MIT)                                                                           |
-| `origin`            | Name of the region of origin (e.g. France, Australia, Hong Kong). Excludes states within a federation (e.g. California) |
-| `website`           | Full URL to the OS's website                                                                                            |
-| `repository`        | Full URL to the OS's public source repository                                                                           |
-| `donate`            | Full URL to a funding section of the OS's website. Introduced with Tempo                                                |
-| `donate-github`     | Full URL to the OS's GitHub Sponsor page. Introduced with Tempo                                                         |
-| `donate-patreon`    | Full URL to the OS's Patreon page. Introduced with Tempo                                                                |
-| `donate-collective` | Full URL to the OS's Open Collective page. Introduced with Tempo                                                        |
+| Metadata           | Meaning                                                                                                                 |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------- |
+| `title`            | Name of the OS                                                                                                          |
+| `summary`          | Short description of the OS (2-7 words)                                                                                 |
+| `date`             | Date of writing. Year-Month-Date format                                                                                 |
+| `version`          | Version of the OS when written (or written on)                                                                          |
+| `category`         | Category of the OS. See below for more information                                                                      |
+| `platform`         | Popular available platforms, separated by commas                                                                        |
+| `descends`         | The OS that the OS of writing is based on (e.g. Xubuntu/Ubuntu)                                                         |
+| `desktop`          | Name of the preinstalled GUI. To be left blank if none is present, or if the OS boots its CLI by default                |
+| `shell`            | Name of the default shell (e.g. `bash`)                                                                                 |
+| `packagemgr`       | Name of the default package manager. Excludes cross-OS application delivery platforms (e.g. `flatpak`, `snap`)          |
+| `startup`          | Name of the default startup manager (e.g. `systemd`)                                                                    |
+| `size`             | Approximated size of the OS                                                                                             |
+| `browser`          | Name of the preinstalled web browser (e.g. Firefox)                                                                     |
+| `productivity`     | Name of the preinstalled office software suite (e.g. LibreOffice)                                                       |
+| `licence`          | Name of the licence used by the OS (e.g. MIT)                                                                           |
+| `origin`           | Name of the region of origin (e.g. France, Australia, Hong Kong). Excludes states within a federation (e.g. California) |
+| `website`          | Full URL to the OS's website                                                                                            |
+| `repository`       | Full URL to the OS's public source repository                                                                           |
+| `donate`           | Full URL to a funding section of the OS's website. Introduced with Tempo                                                |
+| `donateGithub`     | Full URL to the OS's GitHub Sponsor page. Introduced with Tempo                                                         |
+| `donatePatreon`    | Full URL to the OS's Patreon page. Introduced with Tempo                                                                |
+| `donateCollective` | Full URL to the OS's Open Collective page. Introduced with Tempo                                                        |
 
 ## Category definitions
 

--- a/STACK.md
+++ b/STACK.md
@@ -1,6 +1,6 @@
-# Stack details
+# Stack references
 
-This is a reference outline of the ULOSINO stack.
+This is a reference to ULOSINO features, and an outline of the ULOSINO stack and architecture.
 
 ## Project structure
 
@@ -48,6 +48,46 @@ These are the primary providers:
 
 `UtterancesProvider` provides comments to OS Pages, using the Utterances utility and GitHub issues. It's imported on `browse/[slug].tsx`.
 
+## Metadata definitions
+
+`title`, `summary`, `date`, `platform` and `version` are required for sorting. All other metadata fields will be hidden if they have no value. Updated with version 1.4.0.
+
+| Metadata            | Meaning                                                                                                                 |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `title`             | Name of the OS                                                                                                          |
+| `summary`           | Short description of the OS (2-7 words)                                                                                 |
+| `date`              | Date of writing. Year-Month-Date format                                                                                 |
+| `version`           | Version of the OS when written (or written on)                                                                          |
+| `category`          | Category of the OS. See below for more information                                                                      |
+| `platform`          | Popular available platforms, separated by commas                                                                        |
+| `descends`          | The OS that the OS of writing is based on (e.g. Xubuntu/Ubuntu)                                                         |
+| `desktop`           | Name of the preinstalled GUI. To be left blank if none is present, or if the OS boots its CLI by default                |
+| `shell`             | Name of the default shell (e.g. `bash`)                                                                                 |
+| `packagemgr`        | Name of the default package manager. Excludes cross-OS application delivery platforms (e.g. `flatpak`, `snap`)          |
+| `startup`           | Name of the default startup manager (e.g. `systemd`)                                                                    |
+| `size`              | Approximated size of the OS                                                                                             |
+| `browser`           | Name of the preinstalled web browser (e.g. Firefox)                                                                     |
+| `productivity`      | Name of the preinstalled office software suite (e.g. LibreOffice)                                                       |
+| `licence`           | Name of the licence used by the OS (e.g. MIT)                                                                           |
+| `origin`            | Name of the region of origin (e.g. France, Australia, Hong Kong). Excludes states within a federation (e.g. California) |
+| `website`           | Full URL to the OS's website                                                                                            |
+| `repository`        | Full URL to the OS's public source repository                                                                           |
+| `donate`            | Full URL to a funding section of the OS's website. Introduced with Tempo                                                |
+| `donate-github`     | Full URL to the OS's GitHub Sponsor page. Introduced with Tempo                                                         |
+| `donate-patreon`    | Full URL to the OS's Patreon page. Introduced with Tempo                                                                |
+| `donate-collective` | Full URL to the OS's Open Collective page. Introduced with Tempo                                                        |
+
+## Category definitions
+
+| Category   | Meaning                                                                                           |
+| ---------- | ------------------------------------------------------------------------------------------------- |
+| Desktop    | Intended for general computing and uses a GUI by default                                          |
+| Mobile     | Intended for general computing on mobile devices                                                  |
+| Advanced   | Requires learning to use — intended for power-users and developers                                |
+| Utility    | Intended for highly specialised use cases, usually preinstalled with utility software             |
+| Enterprise | Intended for large-scale corporate use — often available with paid support                        |
+| Research   | Intended to showcase different approaches to computing concepts — may be unstable or discontinued |
+
 ## Other details
 
 ### Testing
@@ -69,4 +109,4 @@ ULOSINO uses the MIT license. This allows you to copy or study the ULOSINO stack
 
 ---
 
-Last revised 18th December, 2021.
+Last revised 17th January, 2022 (`1.4.0`).

--- a/cypress/integration/database.spec.js
+++ b/cypress/integration/database.spec.js
@@ -10,7 +10,13 @@ describe("Database Tester", () => {
     // Test in-page metadata
     cy.get("h2").contains("Operating system page demo");
     cy.get("p").contains("This isn't an operating system.");
-    cy.get("td").contains("Website");
+    cy.get("td").contains("Licence");
+
+    // Test in-page buttons where metadata forms the href
+    cy.get("#testing-db-websiteLinkButton")
+      .contains("Visit Website")
+      .should("have.attr", "href")
+      .and("include", "ulosino.com");
 
     // Test remote metadata
     cy.get("button").contains("Browse").click();

--- a/public/content/browse/alpine.mdx
+++ b/public/content/browse/alpine.mdx
@@ -17,8 +17,8 @@ size: "150mb"
 browser: ""
 licence: ""
 origin: ""
-website: "alpinelinux.org"
-repository: "gitlab.alpinelinux.org/alpine"
+website: "https://alpinelinux.org"
+repository: "https://gitlab.alpinelinux.org/alpine"
 ---
 
 [Alpine Linux](https://alpinelinux.org) is an "independent" Linux distribution. Targeting power users, it ships a command line interface. Alpine is designed for those who "appreciate security, simplicity, and resource efficiency" and has a wide array of applications in the server, container, and VM industries. Alpine also ships with a custom software repository called apk ("Alpine Package Keeper"). It's available on x86, arm, and risc-v, and legacy platforms including PowerPC and even IBM's System/390 - it's server roots are apparent; it requires Ethernet for a wizard-based setup (the de facto standard). Alpine only provides the total basics (not even `nano`), which is something quite unique.

--- a/public/content/browse/antix.mdx
+++ b/public/content/browse/antix.mdx
@@ -17,7 +17,7 @@ size: "1300mb"
 browser: ""
 licence: ""
 origin: "Greece"
-website: "antixlinux.org"
+website: "https://antixlinux.org"
 repository: ""
 ---
 

--- a/public/content/browse/arch.mdx
+++ b/public/content/browse/arch.mdx
@@ -17,7 +17,7 @@ size: ""
 browser: "Firefox"
 licence: ""
 origin: ""
-website: "archlinux.org"
+website: "https://archlinux.org"
 repository: ""
 ---
 

--- a/public/content/browse/artix.mdx
+++ b/public/content/browse/artix.mdx
@@ -17,7 +17,7 @@ size: "900mb"
 browser: ""
 licence: ""
 origin: ""
-website: "artixlinux.org"
+website: "https://artixlinux.org"
 repository: ""
 ---
 

--- a/public/content/browse/debian.mdx
+++ b/public/content/browse/debian.mdx
@@ -17,7 +17,7 @@ size: ""
 browser: ""
 licence: ""
 origin: ""
-website: "www.debian.org"
+website: "https://www.debian.org"
 repository: ""
 ---
 

--- a/public/content/browse/demo.mdx
+++ b/public/content/browse/demo.mdx
@@ -17,8 +17,8 @@ size: ""
 browser: ""
 licence: "MIT"
 origin: ""
-website: "ulosino.com"
-repository: "github.com/ulosino/ulosino"
+website: "https://ulosino.com"
+repository: "https://github.com/ulosino/ulosino"
 ---
 
 This is a demo for the OS page system. **This isn't an operating system.**

--- a/public/content/browse/dragonflybsd.mdx
+++ b/public/content/browse/dragonflybsd.mdx
@@ -17,7 +17,7 @@ size: ""
 browser: ""
 licence: ""
 origin: ""
-website: "www.dragonflybsd.org"
+website: "https://www.dragonflybsd.org"
 repository: ""
 ---
 

--- a/public/content/browse/elementary.mdx
+++ b/public/content/browse/elementary.mdx
@@ -17,8 +17,8 @@ size: ""
 browser: "Web (Epiphany)"
 licence: ""
 origin: ""
-website: "elementary.io"
-repository: "github.com/elementary"
+website: "https://elementary.io"
+repository: "https://github.com/elementary"
 ---
 
 ---

--- a/public/content/browse/elementary.mdx
+++ b/public/content/browse/elementary.mdx
@@ -19,6 +19,12 @@ licence: ""
 origin: ""
 website: "https://elementary.io"
 repository: "https://github.com/elementary"
+
+# ULOSINO Tempo donation options
+donate: "https://elementary.io/get-involved#funding" # Required, link to all donation options
+# donateCollective: "" # Open Collective
+donateGithub: "https://github.com/sponsors/elementary"
+donatePatreon: "https://www.patreon.com/elementary"
 ---
 
 ---

--- a/public/content/browse/endeavour.mdx
+++ b/public/content/browse/endeavour.mdx
@@ -17,7 +17,7 @@ size: "2000mb"
 browser: "Firefox"
 licence: ""
 origin: "Netherlands"
-website: "endeavouros.com"
+website: "https://endeavouros.com"
 repository: ""
 ---
 

--- a/public/content/browse/eurolinux.mdx
+++ b/public/content/browse/eurolinux.mdx
@@ -17,7 +17,7 @@ size: ""
 browser: "Firefox"
 licence: ""
 origin: ""
-website: "en.euro-linux.com/eurolinux/"
+website: "https://en.euro-linux.com/eurolinux/"
 repository: ""
 ---
 

--- a/public/content/browse/fedora.mdx
+++ b/public/content/browse/fedora.mdx
@@ -17,7 +17,7 @@ size: ""
 browser: "Firefox"
 licence: ""
 origin: ""
-website: "getfedora.com"
+website: "https://getfedora.com"
 repository: ""
 ---
 

--- a/public/content/browse/feren.mdx
+++ b/public/content/browse/feren.mdx
@@ -17,7 +17,7 @@ size: ""
 browser: "Firefox"
 licence: ""
 origin: "England"
-website: "feren.weebly.com"
+website: "https://feren.weebly.com"
 repository: ""
 ---
 

--- a/public/content/browse/freebsd.mdx
+++ b/public/content/browse/freebsd.mdx
@@ -17,8 +17,8 @@ size: ""
 browser: ""
 licence: ""
 origin: ""
-website: "www.freebsd.org"
-repository: "cgit.freebsd.org"
+website: "https://www.freebsd.org"
+repository: "https://cgit.freebsd.org"
 ---
 
 [FreeBSD](https://www.freebsd.org) is a mature BSD-based OS. First released in 1995, it targets both the general and server (notably networking) markets. FreeBSD has a loyal fanbase and aims to be a "complete operating system" so to "relize the full potential of any computer". Much of the work that happens with FreeBSD is at the core of the OS, with many innovations in the I/O, TCP/IP (Internet), LLVM, and subsystem fields. Well known for this innovative stance (in addition to it's strong foundation), it has formed the base for Netflix servers, PlayStation system software, and Apple products (through macOS and Darwin) across the world. John Baldwin, a FreeBSD developer for 25 years running, has said that it is both "phenomenal" and "bizzare" that his "son's PS4 runs [his] code all the time." The lasting footprint that the FreeBSD project has given to the world is certainly quite large.

--- a/public/content/browse/garden.mdx
+++ b/public/content/browse/garden.mdx
@@ -17,8 +17,8 @@ size: ""
 browser: ""
 licence: ""
 origin: "Germany"
-website: "gardenlinux.io"
-repository: "github.com/gardenlinux/gardenlinux"
+website: "https://gardenlinux.io"
+repository: "https://github.com/gardenlinux/gardenlinux"
 ---
 
 [Garden Linux](https://gardenlinux.io) is an open-source OS designed for servers and virtual machine deployments. It targets the cloud and enterprise markets. Garden descends Debian and aims to be a "small, auditable" system, with "repeatable" builds. The releases and builds use a "feature system" and are tailored to different platforms (like AWS) and features. It's also built with CI in mind. The "whole setup is purely systemd based," including networking. Garden allows for Linux on a variety of deployment environments.

--- a/public/content/browse/garuda.mdx
+++ b/public/content/browse/garuda.mdx
@@ -17,8 +17,8 @@ size: ""
 browser: "FireDragon"
 licence: ""
 origin: "India"
-website: "garudalinux.org"
-repository: "gitlab.com/garuda-linux"
+website: "https://garudalinux.org"
+repository: "https://gitlab.com/garuda-linux"
 ---
 
 [Garuda Linux](https://garudalinux.org) ("Garuda") is an Linux distribution based on the Arch platform. It targets the power-user and general computing markets. Garuda extends Arch by implementing multiple stability and security features like custom memory management, custom kernel scheduling, the Linux-zen modified kernel, and the "modern copy-on-write" BTRFS file system. The aim is to provide an OSs that is focussed on "performance while making it beautiful," as there are many GUI utilities, including a graphical installation - a major draw card for who prefer Arch.

--- a/public/content/browse/gentoo.mdx
+++ b/public/content/browse/gentoo.mdx
@@ -17,7 +17,7 @@ size: ""
 browser: ""
 licence: ""
 origin: ""
-website: "www.gentoo.org"
+website: "https://www.gentoo.org"
 repository: ""
 ---
 

--- a/public/content/browse/ghostbsd.mdx
+++ b/public/content/browse/ghostbsd.mdx
@@ -17,7 +17,7 @@ size: "2500mb"
 browser: "Firefox"
 licence: ""
 origin: "Canada"
-website: "www.ghostbsd.org"
+website: "https://www.ghostbsd.org"
 repository: "github.com/GhostBSD"
 ---
 

--- a/public/content/browse/haiku.mdx
+++ b/public/content/browse/haiku.mdx
@@ -17,7 +17,7 @@ size: "800mb"
 browser: "WebPositive"
 licence: ""
 origin: "Germany"
-website: "haiku-os.org"
+website: "https://haiku-os.org"
 repository: "git.haiku-os.org"
 ---
 

--- a/public/content/browse/kali.mdx
+++ b/public/content/browse/kali.mdx
@@ -17,7 +17,7 @@ size: ""
 browser: "Firefox"
 licence: ""
 origin: "Switzerland"
-website: "kali.org"
+website: "https://kali.org"
 repository: ""
 ---
 

--- a/public/content/browse/kubuntu.mdx
+++ b/public/content/browse/kubuntu.mdx
@@ -17,7 +17,7 @@ size: ""
 browser: "Firefox"
 licence: ""
 origin: ""
-website: "www.kubuntu.org"
+website: "https://www.kubuntu.org"
 repository: ""
 ---
 

--- a/public/content/browse/lakka.mdx
+++ b/public/content/browse/lakka.mdx
@@ -17,7 +17,7 @@ size: ""
 browser: ""
 licence: ""
 origin: "France"
-website: "lakka.tv"
+website: "https://lakka.tv"
 repository: ""
 ---
 

--- a/public/content/browse/leap.mdx
+++ b/public/content/browse/leap.mdx
@@ -17,7 +17,7 @@ size: ""
 browser: "Firefox"
 licence: ""
 origin: "Germany"
-website: "www.opensuse.org/#Leap"
+website: "https://www.opensuse.org/#Leap"
 repository: ""
 ---
 

--- a/public/content/browse/manjaro.mdx
+++ b/public/content/browse/manjaro.mdx
@@ -17,8 +17,8 @@ size: ""
 browser: ""
 licence: ""
 origin: ""
-website: "manjaro.org"
-repository: "gitlab.manjaro.org"
+website: "https://manjaro.org"
+repository: "https://gitlab.manjaro.org"
 ---
 
 [Manjaro](https://manjaro.org) is an Arch-based Linux distribution. Targeting general computing and power-users, Manjaro is a "professionally made" OS aiming to be a replacement to Windows or macOS. It takes the rolling-release platform of Arch but goes for "less manual intervention." Manjaro ships Xfce by default - with many other desktops available - has broad hardware support, is ready out-of-the-box, and shoots for a "traditional UNIX philosophy." However, more advanced features like concurrent kernels are also available.

--- a/public/content/browse/midnightbsd.mdx
+++ b/public/content/browse/midnightbsd.mdx
@@ -17,7 +17,7 @@ size: "700mb"
 browser: ""
 licence: ""
 origin: ""
-website: "www.midnightbsd.org"
+website: "https://www.midnightbsd.org"
 repository: ""
 ---
 

--- a/public/content/browse/mint.mdx
+++ b/public/content/browse/mint.mdx
@@ -17,8 +17,8 @@ size: ""
 browser: "Firefox"
 licence: ""
 origin: ""
-website: "linuxmint.com"
-repository: "github.com/linuxmint"
+website: "https://linuxmint.com"
+repository: "https://github.com/linuxmint"
 ---
 
 ---

--- a/public/content/browse/mx.mdx
+++ b/public/content/browse/mx.mdx
@@ -17,7 +17,7 @@ size: "2250mb"
 browser: ""
 licence: ""
 origin: "Greece"
-website: "mxlinux.org"
+website: "https://mxlinux.org"
 repository: ""
 ---
 

--- a/public/content/browse/neon.mdx
+++ b/public/content/browse/neon.mdx
@@ -17,7 +17,7 @@ size: ""
 browser: "Firefox"
 licence: ""
 origin: ""
-website: "neon.kde.org"
+website: "https://neon.kde.org"
 repository: ""
 ---
 

--- a/public/content/browse/netbsd.mdx
+++ b/public/content/browse/netbsd.mdx
@@ -17,7 +17,7 @@ size: ""
 browser: "Firefox"
 licence: ""
 origin: ""
-website: "www.netbsd.org"
+website: "https://www.netbsd.org"
 repository: ""
 ---
 

--- a/public/content/browse/nitrux.mdx
+++ b/public/content/browse/nitrux.mdx
@@ -17,7 +17,7 @@ size: ""
 browser: "Firefox"
 licence: ""
 origin: ""
-website: "nxos.org"
+website: "https://nxos.org"
 repository: ""
 ---
 

--- a/public/content/browse/nixos.mdx
+++ b/public/content/browse/nixos.mdx
@@ -17,7 +17,7 @@ size: ""
 browser: ""
 licence: ""
 origin: ""
-website: "nixos.org"
+website: "https://nixos.org"
 repository: ""
 ---
 

--- a/public/content/browse/oasis.mdx
+++ b/public/content/browse/oasis.mdx
@@ -17,8 +17,8 @@ size: ""
 browser: ""
 licence: ""
 origin: ""
-website: "github.com/oasislinux/oasis/wiki"
-repository: "github.com/oasislinux/oasis"
+website: "https://github.com/oasislinux/oasis/wiki"
+repository: "https://github.com/oasislinux/oasis"
 ---
 
 [oasis](https://github.com/oasislinux/oasis/wiki) is an independent Linux distribution, with considerable BSD characteristics. "An ambitions project," it targets the power-user market. oasis is new to the scene; the "principles" here are "statically linked executables," simple file-based system configuration (within `/etc`), and overall modularity. oasis has no package management by default but "integrates well with OS-agnostic" repositories like `pkgsrc` (from NetBSD) and `nix`. A major feature here is a Lua-powered build system that shifts away from direct maintanence to "considerable up-front packaging cost." Pre-installed software are assorted into "sets" that can be easily managed.

--- a/public/content/browse/openbsd.mdx
+++ b/public/content/browse/openbsd.mdx
@@ -17,8 +17,8 @@ size: ""
 browser: ""
 licence: ""
 origin: ""
-website: "www.openbsd.org"
-repository: "cvsweb.openbsd.org/cgi-bin/cvsweb/"
+website: "https://www.openbsd.org"
+repository: "https://cvsweb.openbsd.org/cgi-bin/cvsweb/"
 ---
 
 [OpenBSD](http://www.openbsd.org) is a BSD operating system, based on BSD 4.4. OpenBSD targets the developer and power-user markets. Working on a biannual release scheme, OpenBSD is of the three founding BSD 4.4 derivatives (including FreeBSD and NetBSD), and is now on it's 51st release. A "developer-oriented" project, OpenBSD takes a minimalist approach to BSD, emphasising portability, cryptography, and "correctness." The project is also attempting to create the "most secure operating system. However the OS is often considered to be to stiff for those new to Unix.

--- a/public/content/browse/peppermint.mdx
+++ b/public/content/browse/peppermint.mdx
@@ -17,7 +17,7 @@ size: ""
 browser: "Firefox"
 licence: ""
 origin: ""
-website: "peppermintos.com"
+website: "https://peppermintos.com"
 repository: ""
 ---
 

--- a/public/content/browse/plan9.mdx
+++ b/public/content/browse/plan9.mdx
@@ -17,8 +17,8 @@ size: ""
 browser: ""
 licence: "MIT"
 origin: ""
-website: "9p.io/plan9/"
-repository: "9p.io/sources/plan9/sys/src/"
+website: "https://9p.io/plan9/"
+repository: "https://9p.io/sources/plan9/sys/src/"
 ---
 
 [Plan 9 from Bell Labs](http://9p.io/plan9/) is a distributed operating system originally developed by Bell Labs and now open source. Plan 9 builds upon Unix concepts, and targets the general computing and research markets. The final official release, version 4, was finalised in 2015 - however the OS has been ported across many platforms and a handful of derivatives exist. With development initiated in the late 1980s, Plan 9 "demonstrates a cleaner way" to work an operating system, tightly integrating the then-new Internet into a unified communications protocol, known as the 9P Protocol. The 9P Protocol extends the Unix "everything is a file" model into local, network, and inter-process communications, removing the need for specialised APIs. Thus, the Unix influence feels "familiar" but "quite foreign." Files are even used to manage processes and interfacing with networking hardware - one can `cd` into the `/proc` folder and use file system tools to view processes running on their system. A union file system is also available, allowing complex applications of Plan 9. Additionally, beginning in 1992, Unicode is natively implemented. Another artifact from being developed many decades after Unix is that Plan 9 delivers a hyperlinked GUI out-of-the-box and by default. `rio` uses a system of windows, treated as text, to allow the user to run software. However, Unix compatibility was not intended and is poor. Ultimately, Plan 9 has suffered from low adoption due to the general lack of software and drivers as a result of it's ambitious approach.

--- a/public/content/browse/popos.mdx
+++ b/public/content/browse/popos.mdx
@@ -17,7 +17,7 @@ size: ""
 browser: "Firefox"
 licence: ""
 origin: "United States"
-website: "pop.system76.com"
+website: "https://pop.system76.com"
 repository: ""
 ---
 

--- a/public/content/browse/q4os.mdx
+++ b/public/content/browse/q4os.mdx
@@ -17,7 +17,7 @@ size: ""
 browser: "Chromium"
 licence: ""
 origin: ""
-website: "q4os.org"
+website: "https://q4os.org"
 repository: ""
 ---
 

--- a/public/content/browse/raspberrypi.mdx
+++ b/public/content/browse/raspberrypi.mdx
@@ -17,7 +17,7 @@ size: "1000-4000mb"
 browser: "Chromium"
 licence: ""
 origin: "United Kingdom"
-website: "www.raspberrypi.com/software/"
+website: "https://www.raspberrypi.com/software/"
 repository: ""
 ---
 

--- a/public/content/browse/reactos.mdx
+++ b/public/content/browse/reactos.mdx
@@ -17,8 +17,8 @@ size: ""
 browser: "Firefox"
 licence: "GPL 2.0"
 origin: "Russia"
-website: "reactos.org"
-repository: "github.com/reactos"
+website: "https://reactos.org"
+repository: "https://github.com/reactos"
 ---
 
 ---

--- a/public/content/browse/rhel.mdx
+++ b/public/content/browse/rhel.mdx
@@ -17,7 +17,7 @@ size: ""
 browser: "Firefox"
 licence: ""
 origin: ""
-website: "www.redhat.com/en/technologies/linux-platforms/enterprise-linux"
+website: "https://www.redhat.com/en/technologies/linux-platforms/enterprise-linux"
 repository: ""
 ---
 

--- a/public/content/browse/rocky.mdx
+++ b/public/content/browse/rocky.mdx
@@ -17,8 +17,8 @@ size: ""
 browser: "Firefox"
 licence: ""
 origin: ""
-website: "rockylinux.org"
-repository: "github.com/rocky-linux"
+website: "https://rockylinux.org"
+repository: "https://github.com/rocky-linux"
 ---
 
 ---

--- a/public/content/browse/serenity.mdx
+++ b/public/content/browse/serenity.mdx
@@ -17,8 +17,8 @@ size: ""
 browser: "SerenityOS Browser"
 licence: "BSD 2-Clause"
 origin: ""
-website: "serenityos.org"
-repository: "github.com/SerenityOS/serenity"
+website: "https://serenityos.org"
+repository: "https://github.com/SerenityOS/serenity"
 ---
 
 ---

--- a/public/content/browse/solus.mdx
+++ b/public/content/browse/solus.mdx
@@ -17,7 +17,7 @@ size: ""
 browser: "Firefox"
 licence: ""
 origin: "Ireland"
-website: "getsol.us"
+website: "https://getsol.us"
 repository: ""
 ---
 

--- a/public/content/browse/steamos.mdx
+++ b/public/content/browse/steamos.mdx
@@ -17,7 +17,7 @@ size: "1500mb"
 browser: ""
 licence: ""
 origin: ""
-website: "store.steampowered.com/steamos/"
+website: "https://store.steampowered.com/steamos/"
 repository: ""
 ---
 

--- a/public/content/browse/systemrescue.mdx
+++ b/public/content/browse/systemrescue.mdx
@@ -17,7 +17,7 @@ size: "800mb"
 browser: ""
 licence: ""
 origin: ""
-website: "system-rescue.org"
+website: "https://system-rescue.org"
 repository: ""
 ---
 

--- a/public/content/browse/tails.mdx
+++ b/public/content/browse/tails.mdx
@@ -17,7 +17,7 @@ size: "1.2gb"
 browser: "Firefox"
 licence: ""
 origin: ""
-website: "tails.boum.org"
+website: "https://tails.boum.org"
 repository: ""
 ---
 

--- a/public/content/browse/truenas.mdx
+++ b/public/content/browse/truenas.mdx
@@ -17,7 +17,7 @@ size: ""
 browser: ""
 licence: ""
 origin: ""
-website: "www.truenas.com/truenas-core/"
+website: "https://www.truenas.com/truenas-core/"
 repository: ""
 ---
 

--- a/public/content/browse/tumbleweed.mdx
+++ b/public/content/browse/tumbleweed.mdx
@@ -17,7 +17,7 @@ size: ""
 browser: "Firefox"
 licence: ""
 origin: "Germany"
-website: "www.opensuse.org/#Tumbleweed"
+website: "https://www.opensuse.org/#Tumbleweed"
 repository: ""
 ---
 

--- a/public/content/browse/ubports.mdx
+++ b/public/content/browse/ubports.mdx
@@ -17,7 +17,7 @@ size: ""
 browser: "Morph Browser"
 licence: ""
 origin: "Norway"
-website: "ubports.com"
+website: "https://ubports.com"
 repository: ""
 ---
 

--- a/public/content/browse/ubuntu-mate.mdx
+++ b/public/content/browse/ubuntu-mate.mdx
@@ -17,7 +17,7 @@ size: ""
 browser: ""
 licence: ""
 origin: ""
-website: "ubuntu-mate.org"
+website: "https://ubuntu-mate.org"
 repository: ""
 ---
 

--- a/public/content/browse/ubuntu-studio.mdx
+++ b/public/content/browse/ubuntu-studio.mdx
@@ -17,7 +17,7 @@ size: ""
 browser: ""
 licence: ""
 origin: ""
-website: "ubuntustudio.org"
+website: "https://ubuntustudio.org"
 repository: ""
 ---
 

--- a/public/content/browse/ubuntu.mdx
+++ b/public/content/browse/ubuntu.mdx
@@ -17,7 +17,7 @@ size: ""
 browser: "Firefox"
 licence: ""
 origin: ""
-website: "ubuntu.com"
+website: "https://ubuntu.com"
 repository: ""
 ---
 

--- a/public/content/browse/void.mdx
+++ b/public/content/browse/void.mdx
@@ -17,7 +17,7 @@ size: ""
 browser: ""
 licence: ""
 origin: ""
-website: "voidlinux.org"
+website: "https://voidlinux.org"
 repository: ""
 ---
 

--- a/public/content/browse/whonix.mdx
+++ b/public/content/browse/whonix.mdx
@@ -17,8 +17,8 @@ size: ""
 browser: ""
 licence: ""
 origin: ""
-website: "www.whonix.org"
-repository: "github.com/Whonix/Whonix"
+website: "https://www.whonix.org"
+repository: "https://github.com/Whonix/Whonix"
 ---
 
 [Whonix](https://www.whonix.org) is an Debian based Linux distribution. It targets the power-user market. It's a live operating system focussed on security, a bit like Tails. Whonix, as an operating system ("Whonix-Workstation") connects to the "Whonix-Gateway" set of voluteer-run virtual machines. The workstation (OS) intended as the place to run Tor - from there traffic is routed through the Tor network and the VM, and then onto the Internet. Other security hardening exists, like enhancements to the kernel. Whonix can only be run in a virtual machine, further hardening security. Whonix has more protections than competitors, but has a steeper learning curve and complexity.

--- a/public/content/browse/xubuntu.mdx
+++ b/public/content/browse/xubuntu.mdx
@@ -17,8 +17,8 @@ size: ""
 browser: "Firefox"
 licence: ""
 origin: ""
-website: "www.xubuntu.org"
-repository: "github.com/Xubuntu"
+website: "https://www.xubuntu.org"
+repository: "https://github.com/Xubuntu"
 ---
 
 ---

--- a/public/content/browse/zorin-core.mdx
+++ b/public/content/browse/zorin-core.mdx
@@ -17,7 +17,7 @@ size: ""
 browser: "Firefox"
 licence: ""
 origin: "Ireland"
-website: "zorin.com/os/"
+website: "https://zorin.com/os/"
 repository: ""
 ---
 

--- a/public/content/browse/zorin-pro.mdx
+++ b/public/content/browse/zorin-pro.mdx
@@ -17,7 +17,7 @@ size: ""
 browser: "Firefox"
 licence: ""
 origin: "Ireland"
-website: "zorin.com/os/pro/"
+website: "https://zorin.com/os/pro/"
 repository: ""
 ---
 

--- a/src/UIProvider.tsx
+++ b/src/UIProvider.tsx
@@ -6,8 +6,16 @@ import {
   StartNavigationDesktop,
   StartNavigationMobile,
 } from "src/components/StartNavigation";
-import EndNavigation from "src/components/EndNavigation";
-import LegalNavigation from "./components/LegalNavigation";
+
+import dynamic from "next/dynamic";
+import Loading from "src/components/Loading";
+const EndNavigation = dynamic(() => import("src/components/EndNavigation"), {
+  loading: () => <Loading />,
+});
+const LegalNavigation = dynamic(
+  () => import("src/components/LegalNavigation"),
+  { loading: () => <Loading /> }
+);
 
 export default function UIProvider({ children }) {
   return (

--- a/src/UIThemeProvider.ts
+++ b/src/UIThemeProvider.ts
@@ -56,7 +56,7 @@ export const Card = {
 };
 
 const Badge = {
-  baseStyle: { px: 4, pt: "0.5", h: "20px" },
+  baseStyle: { px: 4, pt: "0.5", h: "20px", shadow: "md" },
   sizes: {
     sm: {
       fontSize: "xs",
@@ -71,7 +71,10 @@ const Badge = {
     solid: {
       bg: "secondary",
       color: "white",
-      shadow: "md",
+    },
+    alert: {
+      bg: "alert",
+      color: "gray.800",
     },
   },
   defaultProps: {

--- a/src/UtterancesProvider.js
+++ b/src/UtterancesProvider.js
@@ -11,6 +11,7 @@ const validTypeList = [
   "url",
   "title",
   "label",
+  "theme",
   "og:title",
   "issue-number",
   "issue-term",
@@ -41,6 +42,8 @@ const getAttrValue = (type, specificTerm, issueNumber) => {
     return "og:title";
   } else if (type === "label") {
     return "label";
+  } else if (type === "theme") {
+    return "theme";
   } else if (type === "issue-term") {
     return specificTerm;
   } else if (type === "issue-number") {
@@ -56,7 +59,7 @@ class Utterances extends Component {
   }
 
   componentDidMount() {
-    const { repo, type, label, specificTerm, issueNumber } = this.props;
+    const { repo, type, label, theme, specificTerm, issueNumber } = this.props;
     const attrName = getAttrName(type);
     const value = getAttrValue(type, specificTerm, issueNumber);
     if (type === "issue-term" && !value) {
@@ -75,6 +78,7 @@ class Utterances extends Component {
     scriptEl.async = true;
     scriptEl.setAttribute("repo", repo);
     scriptEl.setAttribute("label", label);
+    scriptEl.setAttribute("theme", theme);
     scriptEl.setAttribute("crossorigin", "anonymous");
     scriptEl.setAttribute(attrName, value);
     scriptEl.onload = () => this.setState({ pending: false });
@@ -124,6 +128,10 @@ export const identifierTypes = {
   label: {
     attrValue: "label",
     summary: "Issue label contains issue label",
+  },
+  theme: {
+    attrValue: "theme",
+    summary: "Issue theme contains theme",
   },
   "issue-number": {
     attrValue: -1,

--- a/src/components/DiscussionModal.tsx
+++ b/src/components/DiscussionModal.tsx
@@ -1,18 +1,30 @@
 import {
   Button,
-  Modal,
-  ModalOverlay,
   ModalContent,
-  ModalHeader,
   ModalCloseButton,
-  ModalBody,
-  ModalFooter,
   useDisclosure,
 } from "@chakra-ui/react";
 import { HiOutlineChatAlt2 } from "react-icons/hi";
 
 import dynamic from "next/dynamic";
 const Utterances = dynamic(() => import("src/UtterancesProvider"));
+
+// Dynamically import Tempo experience components to cut performance on pages where Tempo isn't available
+const Modal = dynamic(() =>
+  import("@chakra-ui/react").then((mod) => mod.Modal)
+);
+const ModalOverlay = dynamic(() =>
+  import("@chakra-ui/react").then((mod) => mod.ModalOverlay)
+);
+const ModalHeader = dynamic(() =>
+  import("@chakra-ui/react").then((mod) => mod.ModalHeader)
+);
+const ModalBody = dynamic(() =>
+  import("@chakra-ui/react").then((mod) => mod.ModalBody)
+);
+const ModalFooter = dynamic(() =>
+  import("@chakra-ui/react").then((mod) => mod.ModalFooter)
+);
 
 export default function DiscussionModal() {
   const { isOpen, onOpen, onClose } = useDisclosure();

--- a/src/components/DiscussionModal.tsx
+++ b/src/components/DiscussionModal.tsx
@@ -1,0 +1,53 @@
+import {
+  Button,
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalCloseButton,
+  ModalBody,
+  ModalFooter,
+  useDisclosure,
+} from "@chakra-ui/react";
+import { HiOutlineChatAlt2 } from "react-icons/hi";
+
+import dynamic from "next/dynamic";
+const Utterances = dynamic(() => import("src/UtterancesProvider"));
+
+export default function DiscussionModal() {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  return (
+    <>
+      <Button
+        leftIcon={<HiOutlineChatAlt2 />}
+        aria-label="Show comments for this operating system"
+        onClick={onOpen}
+      >
+        Show Comments
+      </Button>
+      <Modal
+        isOpen={isOpen}
+        onClose={onClose}
+        isCentered
+        motionPreset="scale"
+        size="sm"
+      >
+        <ModalOverlay />
+        <ModalContent rounded="2xl">
+          <ModalHeader>Discuss this OS</ModalHeader>
+          <ModalCloseButton rounded="xl" />
+          <ModalBody>
+            <Utterances
+              repo={"ulosino/ulosino"}
+              label={"Page Comments"}
+              type={"pathname"}
+            />
+          </ModalBody>
+          <ModalFooter>
+            <Button onClick={onClose}>Done</Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
+  );
+}

--- a/src/components/DiscussionModal.tsx
+++ b/src/components/DiscussionModal.tsx
@@ -31,6 +31,7 @@ export default function DiscussionModal() {
         isCentered
         motionPreset="scale"
         size="sm"
+        scrollBehavior="inside"
       >
         <ModalOverlay />
         <ModalContent rounded="2xl">
@@ -41,6 +42,7 @@ export default function DiscussionModal() {
               repo={"ulosino/ulosino"}
               label={"Page Comments"}
               type={"pathname"}
+              theme={"preferred-color-scheme"}
             />
           </ModalBody>
           <ModalFooter>

--- a/src/components/EndNavigation.tsx
+++ b/src/components/EndNavigation.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 
 import { Stack, Flex, Spacer, Center, Button } from "@chakra-ui/react";
-import { HiArrowUp, HiOutlineSupport, HiCode } from "react-icons/hi";
+import { HiArrowUp, HiOutlineSupport, HiOutlineCode } from "react-icons/hi";
 import { FiTwitter } from "react-icons/fi";
 
 import LegalNavigation from "src/components/LegalNavigation";
@@ -24,7 +24,7 @@ export default function EndNavigation() {
           </Button>
         </Link>
         <Link href="https://github.com/ulosino/ulosino" passHref>
-          <Button leftIcon={<HiCode />} size="sm" variant="ghost">
+          <Button leftIcon={<HiOutlineCode />} size="sm" variant="ghost">
             GitHub
           </Button>
         </Link>

--- a/src/components/NavigationMenu.tsx
+++ b/src/components/NavigationMenu.tsx
@@ -24,7 +24,7 @@ import {
 import {
   HiMenu,
   HiChevronRight,
-  HiCode,
+  HiOutlineCode,
   HiOutlineChatAlt2,
   HiOutlineColorSwatch,
 } from "react-icons/hi";
@@ -130,7 +130,11 @@ export default function NavigationMenu() {
                     </Button>
                   </Link>
                   <Link href="https://github.com/ulosino/ulosino" passHref>
-                    <Button leftIcon={<HiCode />} size="sm" onClick={onClose}>
+                    <Button
+                      leftIcon={<HiOutlineCode />}
+                      size="sm"
+                      onClick={onClose}
+                    >
                       GitHub &amp; Source
                     </Button>
                   </Link>

--- a/src/components/NavigationMenu.tsx
+++ b/src/components/NavigationMenu.tsx
@@ -8,7 +8,6 @@ import {
   IconButton,
   Box,
   Stack,
-  SimpleGrid,
   Flex,
   Spacer,
   Modal,

--- a/src/components/NavigationMenu.tsx
+++ b/src/components/NavigationMenu.tsx
@@ -10,13 +10,8 @@ import {
   Stack,
   Flex,
   Spacer,
-  Modal,
-  ModalOverlay,
   ModalContent,
-  ModalHeader,
   ModalCloseButton,
-  ModalBody,
-  ModalFooter,
   useDisclosure,
   useColorMode,
   useBreakpointValue,
@@ -42,6 +37,24 @@ function Card(props) {
     </Box>
   );
 }
+
+import dynamic from "next/dynamic";
+// Dynamically import Tempo experience components to cut performance on pages where Tempo isn't available
+const Modal = dynamic(() =>
+  import("@chakra-ui/react").then((mod) => mod.Modal)
+);
+const ModalOverlay = dynamic(() =>
+  import("@chakra-ui/react").then((mod) => mod.ModalOverlay)
+);
+const ModalHeader = dynamic(() =>
+  import("@chakra-ui/react").then((mod) => mod.ModalHeader)
+);
+const ModalBody = dynamic(() =>
+  import("@chakra-ui/react").then((mod) => mod.ModalBody)
+);
+const ModalFooter = dynamic(() =>
+  import("@chakra-ui/react").then((mod) => mod.ModalFooter)
+);
 
 export default function NavigationMenu() {
   const { isOpen, onOpen, onClose } = useDisclosure();
@@ -70,6 +83,7 @@ export default function NavigationMenu() {
         isCentered
         motionPreset="scale"
         size="sm"
+        scrollBehavior="inside"
       >
         <ModalOverlay />
         <ModalContent rounded="2xl">

--- a/src/components/Version.tsx
+++ b/src/components/Version.tsx
@@ -1,5 +1,5 @@
 // Raw version string
 
 export default function Version() {
-  return <span>1.3.0</span>;
+  return <span>1.4.0</span>;
 }

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { useRouter } from "next/router";
 
 import {
-  Tag,
+  Badge,
   Heading,
   Text,
   Button,
@@ -53,9 +53,7 @@ export default function Custom404() {
               Page Not Found
             </Text>
             <Spacer />
-            <Tag bg="alert" rounded="lg" shadow="md" fontSize="xs">
-              HTTP 404
-            </Tag>
+            <Badge variant="alert">HTTP 404</Badge>
           </Flex>
           <Stack direction="row" spacing={8}>
             <Box display="block">

--- a/src/pages/500.tsx
+++ b/src/pages/500.tsx
@@ -4,7 +4,7 @@ import Head from "next/head";
 import { useRouter } from "next/router";
 
 import {
-  Tag,
+  Badge,
   Heading,
   Text,
   Button,
@@ -48,9 +48,7 @@ export default function Custom500() {
               Server Error
             </Text>
             <Spacer />
-            <Tag bg="alert" rounded="lg" shadow="md" fontSize="xs">
-              HTTP 500
-            </Tag>
+            <Badge variant="alert">HTTP 500</Badge>
           </Flex>
           <Stack direction="row" spacing={8}>
             <Box display="block">

--- a/src/pages/[slug].tsx
+++ b/src/pages/[slug].tsx
@@ -95,13 +95,10 @@ export const getStaticPaths = async () => {
 
   const pageFilePaths = fs
     .readdirSync(pageDataPath)
-    // Only include md(x) files
     .filter((path) => /\.mdx?$/.test(path));
 
   const paths = pageFilePaths
-    // Remove file extensions for page paths
     .map((path) => path.replace(/\.mdx?$/, ""))
-    // Map the path into the static paths object required by Next.js
     .map((slug) => ({ params: { slug } }));
 
   return {

--- a/src/pages/browse/[slug].tsx
+++ b/src/pages/browse/[slug].tsx
@@ -20,7 +20,7 @@ import {
   Td,
   Badge,
 } from "@chakra-ui/react";
-import { HiOutlineCash } from "react-icons/hi";
+import { HiOutlineCash, HiOutlineGlobe, HiOutlineCode } from "react-icons/hi";
 
 import UIProvider from "src/UIProvider";
 
@@ -71,13 +71,27 @@ export default function MDXHostPage({ source, metadata, componentNames }) {
         </Stack>
         <Stack spacing={10}>
           <Stack spacing={2} as="section">
-            <Button leftIcon={<HiOutlineCash />}>
-              Donate
-              <Badge ms={4} bg="brand" color="gray.800" pt={1}>
-                Tempo
-              </Badge>
-            </Button>
             <DiscussionModal />
+            {metadata.donate && (
+              <Link href={metadata.donate} passHref>
+                <Button leftIcon={<HiOutlineCash />}>
+                  Donate
+                  <Badge ms={4} bg="brand" color="gray.800" pt={1}>
+                    Tempo
+                  </Badge>
+                </Button>
+              </Link>
+            )}
+            {metadata.website && (
+              <Link href={metadata.website} passHref>
+                <Button leftIcon={<HiOutlineGlobe />}>Visit Website</Button>
+              </Link>
+            )}
+            {metadata.repository && (
+              <Link href={metadata.repository} passHref>
+                <Button leftIcon={<HiOutlineCode />}>Browse Source</Button>
+              </Link>
+            )}
           </Stack>
           <Stack spacing={2} as="section">
             <Text textStyle="secondary" as="h6">
@@ -85,19 +99,7 @@ export default function MDXHostPage({ source, metadata, componentNames }) {
             </Text>
             <Table>
               <Tbody>
-                {/* Only show the category if the category has any value */}
-                {metadata.website && (
-                  <Tr>
-                    <Td>Website</Td>
-                    <Td>{metadata.website}</Td>
-                  </Tr>
-                )}
-                {metadata.repository && (
-                  <Tr>
-                    <Td>Source Repository</Td>
-                    <Td>{metadata.repository}</Td>
-                  </Tr>
-                )}
+                {/* These are only shown the category if the category has any value */}
                 {metadata.version && (
                   <Tr>
                     <Td>Version</Td>

--- a/src/pages/browse/[slug].tsx
+++ b/src/pages/browse/[slug].tsx
@@ -13,12 +13,20 @@ import {
   Stack,
   Heading,
   Text,
+  Badge,
   Button,
   Table,
   Tbody,
   Tr,
   Td,
-  Badge,
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalCloseButton,
+  ModalBody,
+  ModalFooter,
+  useDisclosure,
 } from "@chakra-ui/react";
 import { HiOutlineCash, HiOutlineGlobe, HiOutlineCode } from "react-icons/hi";
 
@@ -38,6 +46,7 @@ export default function MDXHostPage({ source, metadata, componentNames }) {
     Link: componentNames.includes("Link") ? Link : null,
     Image: componentNames.includes("Image") ? Image : null,
   };
+  const { isOpen, onOpen, onClose } = useDisclosure();
   return (
     <UIProvider>
       <Head>
@@ -73,14 +82,99 @@ export default function MDXHostPage({ source, metadata, componentNames }) {
           <Stack spacing={2} as="section">
             <DiscussionModal />
             {metadata.donate && (
-              <Link href={metadata.donate} passHref>
-                <Button leftIcon={<HiOutlineCash />}>
+              <>
+                <Button
+                  leftIcon={<HiOutlineCash />}
+                  aria-label="Show donation options for this operating system"
+                  onClick={onOpen}
+                >
                   Donate
-                  <Badge ms={4} bg="brand" color="gray.800" pt={1}>
+                  <Badge ms={2} bg="brand" color="gray.800" pt={1}>
                     Tempo
                   </Badge>
                 </Button>
-              </Link>
+                <Modal
+                  isOpen={isOpen}
+                  onClose={onClose}
+                  isCentered
+                  motionPreset="scale"
+                  size="sm"
+                  scrollBehavior="inside"
+                >
+                  <ModalOverlay />
+                  <ModalContent rounded="2xl">
+                    <ModalHeader>Donate to {metadata.title}</ModalHeader>
+                    <ModalCloseButton rounded="xl" />
+                    <ModalBody>
+                      <Stack direction="column" spacing={8}>
+                        <Stack direction="column" spacing={2}>
+                          <Text textStyle="secondary" as="h6">
+                            Visit OS Website
+                          </Text>
+                          {metadata.donate && (
+                            <Link href={metadata.donate} passHref>
+                              <Button leftIcon={<HiOutlineCash />}>
+                                See Donation Options
+                              </Button>
+                            </Link>
+                          )}
+                        </Stack>
+                        <Stack direction="column" spacing={2}>
+                          <Text textStyle="secondary" as="h6">
+                            Quick Donation Options
+                          </Text>
+                          {(metadata.donateCollective && (
+                            <Link href={metadata.donateCollective} passHref>
+                              <Button leftIcon={<HiOutlineCash />}>
+                                Donate through Open Collective
+                              </Button>
+                            </Link>
+                          )) ?? (
+                            <Button leftIcon={<HiOutlineCash />} isDisabled>
+                              Donate through Open Collective
+                            </Button>
+                          )}
+                          {(metadata.donateGithub && (
+                            <Link href={metadata.donateGithub} passHref>
+                              <Button leftIcon={<HiOutlineCash />}>
+                                Donate through GitHub Sponsors
+                              </Button>
+                            </Link>
+                          )) ?? (
+                            <Button leftIcon={<HiOutlineCash />} isDisabled>
+                              Donate through GitHub Sponsors
+                            </Button>
+                          )}
+                          {(metadata.donatePatreon && (
+                            <Link href={metadata.donatePatreon} passHref>
+                              <Button leftIcon={<HiOutlineCash />}>
+                                Donate through Patreon
+                              </Button>
+                            </Link>
+                          )) ?? (
+                            <Button leftIcon={<HiOutlineCash />} isDisabled>
+                              Donate through Patreon
+                            </Button>
+                          )}
+                        </Stack>
+                        <Stack direction="column" spacing={2}>
+                          <Badge bg="brand" color="gray.800" w={210}>
+                            Powered by ULOSINO Tempo
+                          </Badge>
+                        </Stack>
+                        <Text fontSize="xs">
+                          Tempo, the ULOSINO donation hub. Not available for all
+                          donation platforms or for all OSs. ULOSINO does not
+                          receive commission when you use these links.
+                        </Text>
+                      </Stack>
+                    </ModalBody>
+                    <ModalFooter>
+                      <Button onClick={onClose}>Done</Button>
+                    </ModalFooter>
+                  </ModalContent>
+                </Modal>
+              </>
             )}
             {metadata.website && (
               <Link href={metadata.website} passHref>

--- a/src/pages/browse/[slug].tsx
+++ b/src/pages/browse/[slug].tsx
@@ -19,13 +19,8 @@ import {
   Tbody,
   Tr,
   Td,
-  Modal,
-  ModalOverlay,
   ModalContent,
-  ModalHeader,
   ModalCloseButton,
-  ModalBody,
-  ModalFooter,
   useDisclosure,
 } from "@chakra-ui/react";
 import { HiOutlineCash, HiOutlineGlobe, HiOutlineCode } from "react-icons/hi";
@@ -33,6 +28,23 @@ import { HiOutlineCash, HiOutlineGlobe, HiOutlineCode } from "react-icons/hi";
 import UIProvider from "src/UIProvider";
 
 const DiscussionModal = dynamic(() => import("src/components/DiscussionModal"));
+
+// Dynamically import Tempo experience components to cut performance on pages where Tempo isn't available
+const Modal = dynamic(() =>
+  import("@chakra-ui/react").then((mod) => mod.Modal)
+);
+const ModalOverlay = dynamic(() =>
+  import("@chakra-ui/react").then((mod) => mod.ModalOverlay)
+);
+const ModalHeader = dynamic(() =>
+  import("@chakra-ui/react").then((mod) => mod.ModalHeader)
+);
+const ModalBody = dynamic(() =>
+  import("@chakra-ui/react").then((mod) => mod.ModalBody)
+);
+const ModalFooter = dynamic(() =>
+  import("@chakra-ui/react").then((mod) => mod.ModalFooter)
+);
 
 // Pages can use the following components if needed
 const Link = dynamic(() => import("next/link"));

--- a/src/pages/browse/[slug].tsx
+++ b/src/pages/browse/[slug].tsx
@@ -1,8 +1,3 @@
-// TypeScript is disabled on this page due to Utterance comments
-// This is a known bug and will be patched
-
-// @ts-nocheck
-
 import { GetStaticProps } from "next";
 
 import fs from "fs";
@@ -12,29 +7,28 @@ import { MDXRemote } from "next-mdx-remote";
 import { serialize } from "next-mdx-remote/serialize";
 
 import Head from "next/head";
-import { useRouter } from "next/router";
 import dynamic from "next/dynamic";
 
 import {
   Stack,
-  Flex,
-  Spacer,
   Heading,
   Text,
+  Button,
   Table,
   Tbody,
   Tr,
   Td,
-  Button,
   Badge,
 } from "@chakra-ui/react";
-import { FiRefreshCw } from "react-icons/fi";
+import { HiOutlineCash } from "react-icons/hi";
+
 import UIProvider from "src/UIProvider";
+
+const DiscussionModal = dynamic(() => import("src/components/DiscussionModal"));
 
 // Pages can use the following components if needed
 const Link = dynamic(() => import("next/link"));
 const Image = dynamic(() => import("next/image"));
-const Utterances = dynamic(() => import("src/UtterancesProvider"));
 
 const availableComponents = [Link, Image];
 
@@ -44,7 +38,6 @@ export default function MDXHostPage({ source, metadata, componentNames }) {
     Link: componentNames.includes("Link") ? Link : null,
     Image: componentNames.includes("Image") ? Image : null,
   };
-  const router = useRouter();
   return (
     <UIProvider>
       <Head>
@@ -75,128 +68,119 @@ export default function MDXHostPage({ source, metadata, componentNames }) {
             </Text>
             <MDXRemote {...source} components={components} />
           </Stack>
-          <Stack spacing={2} as="section">
-            <Flex>
-              <Text textStyle="secondary" as="h6">
-                Discuss {metadata.title}
-              </Text>
-              <Spacer />
-              <Button
-                leftIcon={<FiRefreshCw />}
-                size="sm"
-                onClick={() => router.reload()}
-              >
-                Refresh
-              </Button>
-            </Flex>
-            <Utterances
-              repo={"ulosino/ulosino"}
-              label={"Page Comments"}
-              type={"pathname"}
-            />
-          </Stack>
         </Stack>
-        <Stack spacing={2} as="section">
-          <Text textStyle="secondary" as="h6">
-            Information
-          </Text>
-          <Table>
-            <Tbody>
-              {/* Only show the category if the category has any value */}
-              {metadata.website && (
-                <Tr>
-                  <Td>Website</Td>
-                  <Td>{metadata.website}</Td>
-                </Tr>
-              )}
-              {metadata.repository && (
-                <Tr>
-                  <Td>Source Repository</Td>
-                  <Td>{metadata.repository}</Td>
-                </Tr>
-              )}
-              {metadata.version && (
-                <Tr>
-                  <Td>Version</Td>
-                  <Td>{metadata.version}</Td>
-                </Tr>
-              )}
-              {metadata.category && (
-                <Tr>
-                  <Td>Category</Td>
-                  <Td>
-                    <Badge>{metadata.category}</Badge>
-                  </Td>
-                </Tr>
-              )}
-              {metadata.descends && (
-                <Tr>
-                  <Td>Based on</Td>
-                  <Td>{metadata.descends}</Td>
-                </Tr>
-              )}
-              {metadata.platform && (
-                <Tr>
-                  <Td>Platforms</Td>
-                  <Td>{metadata.platform}</Td>
-                </Tr>
-              )}
-              {metadata.desktop && (
-                <Tr>
-                  <Td>Preinstalled Desktop</Td>
-                  <Td>{metadata.desktop}</Td>
-                </Tr>
-              )}
-              {metadata.browser && (
-                <Tr>
-                  <Td>Preinstalled Browser</Td>
-                  <Td>{metadata.browser}</Td>
-                </Tr>
-              )}
-              {metadata.productivity && (
-                <Tr>
-                  <Td>Preinstalled Productivity Software</Td>
-                  <Td>{metadata.productivity}</Td>
-                </Tr>
-              )}
-              {metadata.shell && (
-                <Tr>
-                  <Td>Shell</Td>
-                  <Td>{metadata.shell}</Td>
-                </Tr>
-              )}
-              {metadata.packagemgr && (
-                <Tr>
-                  <Td>Package Manager</Td>
-                  <Td>{metadata.packagemgr}</Td>
-                </Tr>
-              )}
-              {metadata.startup && (
-                <Tr>
-                  <Td>Startup Manager</Td>
-                  <Td>{metadata.startup}</Td>
-                </Tr>
-              )}
-              {metadata.size && (
-                <Tr>
-                  <Td>Size</Td>
-                  <Td>{metadata.size}</Td>
-                </Tr>
-              )}
-              {metadata.licence && (
-                <Tr>
-                  <Td>Licence</Td>
-                  <Td>{metadata.licence}</Td>
-                </Tr>
-              )}
-              {metadata.origin && (
-                <Tr>
-                  <Td>Region of Origin</Td>
-                  <Td>{metadata.origin}</Td>
-                </Tr>
-              )}
-            </Tbody>
-          </Table>
+        <Stack spacing={10}>
+          <Stack spacing={2} as="section">
+            <Button leftIcon={<HiOutlineCash />}>
+              Donate
+              <Badge ms={4} bg="brand" color="gray.800" pt={1}>
+                Tempo
+              </Badge>
+            </Button>
+            <DiscussionModal />
+          </Stack>
+          <Stack spacing={2} as="section">
+            <Text textStyle="secondary" as="h6">
+              Information
+            </Text>
+            <Table>
+              <Tbody>
+                {/* Only show the category if the category has any value */}
+                {metadata.website && (
+                  <Tr>
+                    <Td>Website</Td>
+                    <Td>{metadata.website}</Td>
+                  </Tr>
+                )}
+                {metadata.repository && (
+                  <Tr>
+                    <Td>Source Repository</Td>
+                    <Td>{metadata.repository}</Td>
+                  </Tr>
+                )}
+                {metadata.version && (
+                  <Tr>
+                    <Td>Version</Td>
+                    <Td>{metadata.version}</Td>
+                  </Tr>
+                )}
+                {metadata.category && (
+                  <Tr>
+                    <Td>Category</Td>
+                    <Td>
+                      <Badge>{metadata.category}</Badge>
+                    </Td>
+                  </Tr>
+                )}
+                {metadata.descends && (
+                  <Tr>
+                    <Td>Based on</Td>
+                    <Td>{metadata.descends}</Td>
+                  </Tr>
+                )}
+                {metadata.platform && (
+                  <Tr>
+                    <Td>Platforms</Td>
+                    <Td>{metadata.platform}</Td>
+                  </Tr>
+                )}
+                {metadata.desktop && (
+                  <Tr>
+                    <Td>Preinstalled Desktop</Td>
+                    <Td>{metadata.desktop}</Td>
+                  </Tr>
+                )}
+                {metadata.browser && (
+                  <Tr>
+                    <Td>Preinstalled Browser</Td>
+                    <Td>{metadata.browser}</Td>
+                  </Tr>
+                )}
+                {metadata.productivity && (
+                  <Tr>
+                    <Td>Preinstalled Productivity Software</Td>
+                    <Td>{metadata.productivity}</Td>
+                  </Tr>
+                )}
+                {metadata.shell && (
+                  <Tr>
+                    <Td>Shell</Td>
+                    <Td>{metadata.shell}</Td>
+                  </Tr>
+                )}
+                {metadata.packagemgr && (
+                  <Tr>
+                    <Td>Package Manager</Td>
+                    <Td>{metadata.packagemgr}</Td>
+                  </Tr>
+                )}
+                {metadata.startup && (
+                  <Tr>
+                    <Td>Startup Manager</Td>
+                    <Td>{metadata.startup}</Td>
+                  </Tr>
+                )}
+                {metadata.size && (
+                  <Tr>
+                    <Td>Size</Td>
+                    <Td>{metadata.size}</Td>
+                  </Tr>
+                )}
+                {metadata.licence && (
+                  <Tr>
+                    <Td>Licence</Td>
+                    <Td>{metadata.licence}</Td>
+                  </Tr>
+                )}
+                {metadata.origin && (
+                  <Tr>
+                    <Td>Region of Origin</Td>
+                    <Td>{metadata.origin}</Td>
+                  </Tr>
+                )}
+              </Tbody>
+            </Table>
+          </Stack>
         </Stack>
       </Stack>
     </UIProvider>

--- a/src/pages/browse/[slug].tsx
+++ b/src/pages/browse/[slug].tsx
@@ -190,7 +190,12 @@ export default function MDXHostPage({ source, metadata, componentNames }) {
             )}
             {metadata.website && (
               <Link href={metadata.website} passHref>
-                <Button leftIcon={<HiOutlineGlobe />}>Visit Website</Button>
+                <Button
+                  leftIcon={<HiOutlineGlobe />}
+                  id="testing-db-websiteLinkButton"
+                >
+                  Visit Website
+                </Button>
               </Link>
             )}
             {metadata.repository && (


### PR DESCRIPTION
`1.4.0` introduces metadata powered links. Now you can use a button to visit the OS's website and source repository.

In addition, a new set of donation metadata powers the new ULOSINO Tempo community capital hub. With Tempo, you can easily donate and fund your favourite open source operating systems by visiting the OS website or using the range of Quick Donation Options. This will be rolled out to OS pages soon.

This update also includes performance improvements, in particular with dynamic loading and moving comments into a modal.